### PR TITLE
Fix infinite loop when updating with default=None

### DIFF
--- a/zero_downtime_migrations/backend/schema.py
+++ b/zero_downtime_migrations/backend/schema.py
@@ -154,6 +154,8 @@ class ZeroDownTimeMixin(object):
         Updating existing rows in table by (relatively) small batches
         to avoid long locks on table
         """
+        if default_effective_value is None:
+            return
         objects_in_table = self.count_objects_in_table(model=model)
         if objects_in_table > 0:
             objects_in_batch_count = self.get_objects_in_batch_count(objects_in_table)


### PR DESCRIPTION
If migration adds a field with default=None won't be able to complete. For example:
        migrations.AddField(
            model_name='model_name',
            name='column_name',
            field=models.DateField(blank=True, default=None, null=True),
        )