### PR TITLE
Handle -1 value from reltuples

### DIFF
--- a/zero_downtime_migrations/backend/schema.py
+++ b/zero_downtime_migrations/backend/schema.py
@@ -285,9 +285,9 @@ class ZeroDownTimeMixin(object):
             sql=SQL_ESTIMATE_COUNT_IN_TABLE,
             model=model,
         )
-        if count == 0:
+        if count in [0, -1]:
             # Check, maybe statistic is outdated?
-            # Because previous count return 0 it will be fast query
+            # Because previous count return 0 or -1 it will be fast query
             count = self.execute_table_query(
                 sql=SQL_COUNT_IN_TABLE,
                 model=model,


### PR DESCRIPTION
Fixes https://github.com/yandex/zero-downtime-migrations/issues/30.

Since PostgreSQL 14, `reltuples` will return -1 when the table has never been analyzed or vacuumed ([docs](https://www.postgresql.org/docs/14/catalog-pg-class.html)).

This updates the `count_objects_in_table` function to do a COUNT against the table when `reltuples` is -1.

EDIT:
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en